### PR TITLE
Correct minimum version for CLI

### DIFF
--- a/workshop/exercise-1/README.md
+++ b/workshop/exercise-1/README.md
@@ -12,7 +12,7 @@ You should have already carried out the prerequisites defined in [Exercise 0](wo
 
 ```bash
 $ appsody version
-appsody 0.4.8
+appsody 0.4.9
 ```
 
 ## Configure your access to Appsody stacks

--- a/workshop/pre-work/README.md
+++ b/workshop/pre-work/README.md
@@ -15,7 +15,7 @@ A key part of the Appsody development experience is Rapid Local Development Mode
 
 ## 2. Install the Appsody CLI
 
-Appsody includes a CLI which allows you to manage you stack based development (this workshop requries version 0.4.8 or later). This should be installed on your development machine:
+Appsody includes a CLI which allows you to manage you stack based development (this workshop requries version 0.4.9 or later). This should be installed on your development machine:
 
 [Install the Appsody CLI](https://appsody.dev/docs/getting-started/installation)
 
@@ -27,7 +27,7 @@ appsody version
 
 ```bash
 $ appsody version
-appsody 0.4.8
+appsody 0.4.9
 ```
 
 ## 3. Check access to your Managed OpenShift Cluster


### PR DESCRIPTION
My recent update had the incorrect minimum version number