### PR TITLE
replace k6o collection(s) with collection(s)

### DIFF
--- a/workshop/README.md
+++ b/workshop/README.md
@@ -4,7 +4,7 @@
 Welcome to our workshop! In this workshop we'll be using the Cloud Pak for Applications platform to create Cloud Native Applications that run on OpenShift. The goals of this workshop are:
 
 * Use Appsody and Codewind to create a cloud native application
-* Create a custom Kabanero collection
+* Create a custom Collection
 * Use Tekton CI to continuously deploy to OpenShift
 
 ![Tools used in the workshop](.gitbook/images/tools-for-workshop.png)
@@ -34,19 +34,19 @@ In this first day we'll learn how to use Appsody to run the *inner loop* of the 
 | [Lecture 3: Adding value with IBM Cloud Pak for Applications](https://ibm.box.com/s/y4wh104vdos1vw5kdjwwuhebf8jgq580) | Learn about how IBM Cloud Pak for Applications bundles everything together |
 | [Exercise 4: Use Tekton and Kabanero Pipelines to continuously deploy](exercise-4/README.md) | Deploy the built applications to IBM Managed OpenShift using GitOps to trigger a Tekton pipeline |
 
-### Day 2: Customizing Stacks, Pipelines in Kabanero Collections
+### Day 2: Customizing Stacks, Pipelines in Collections
 
-In the second day we'll learn about Kabanero Enterprise and how to productionize our applications with custom Appsody Stacks, custom Kabanero collections, and custom Tekton pipelines.
+In the second day we'll learn about the Kabanero open source project and how to productionize our applications with custom Appsody Stacks, custom Collections, and custom Tekton pipelines.
 
 |   |   |
 | - | - |
 | [Lecture 4: Customizing Appsody and Kabanero](https://ibm.box.com/s/kbuympaqftxswyi1aoswdlqussmqf1ba) | Learn all about the stacks and repos |
-| [Exercise 6: Building a custom Kabanero Collection](exercise-6/README.md) | Create a collection that will contain custom appsody stacks and pipelines |
+| [Exercise 6: Building a custom Collection](exercise-6/README.md) | Create a collection that will contain custom appsody stacks and pipelines |
 | [Exercise 5: Customizing an existing Appsody Stack](exercise-5/README.md) | Create a custom stack, to be hosted in our custom repository |
-| [Exercise 7: Configuring Kabanero to use an Alternate Collection Repository](exercise-7/README.md) | Learn how to manage these custom stacks and how to make them available to developers |
+| [Exercise 7: Using a custom Collection with Appsody](exercise-7/README.md) | Learn how to manage these custom stacks and how to make them available to developers |
 | [Lecture 5: Tekton Overview](https://ibm.box.com/s/tg0f6nhs91trlzkb5pfnh5e1rdzg4wm6) | Learn all Tekton CI/CD and how Kabanero uses it |
-| [Exercise 8: Create a custom Tekton Task and Pipleline](exercise-8/README.md) | Build a pipeline that will fit into a custom Kabanero collection |
-| [Exercise 9: Deploy an application with a custom Stack, custom Collection, and custom Tekton Pipeline](exercise-9/README.md) | Build and deploy an application using the custom stack, collection and pipelines built by the Architects' and Operators' tracks |
+| [Exercise 8: Create a custom Tekton Task and Pipleline](exercise-8/README.md) | Build a pipeline that will fit into a custom Collection |
+| [Exercise 9: Deploy an application with a custom Stack, custom Collection, and custom Pipeline](exercise-9/README.md) | Build and deploy an application using the custom stack, collection and pipelines built by the Architects' and Operators' tracks |
 
 ## Compatability
 
@@ -57,14 +57,14 @@ This workshop has been tested on the following platforms:
 
 ## About Cloud Pak for Applications
 
-IBM Cloud Pak for Applications is an enterprise-ready, containerized software solution for modernizing existing applications and developing new cloud-native apps that run on Red Hat® OpenShift®. Built on IBM WebSphere offerings and Red Hat OpenShift Container Platform with IBM Kabanero Enterprise, Cloud Pak for Applications provides a long-term solution to help you transition between public, private, and hybrid clouds, and create new business applications.
+IBM Cloud Pak for Applications is an enterprise-ready, containerized software solution for modernizing existing applications and developing new cloud-native apps that run on Red Hat® OpenShift®. Built on IBM WebSphere offerings and Red Hat OpenShift Container Platform with the Kabanero open source project, Cloud Pak for Applications provides a long-term solution to help you transition between public, private, and hybrid clouds, and create new business applications.
 
 ### A few other noteworthy mentions
 
 Cloud Pak for Applications:
 
 * ... includes
-  * Kabanero Enterprise
+  * the Kabanero open source project
   * WebSphere
   * Mobile Foundation
   * IBM Cloud Private

--- a/workshop/SUMMARY.md
+++ b/workshop/SUMMARY.md
@@ -15,16 +15,16 @@
     * [Lecture 3: Adding value with IBM Cloud Pak for Applications](https://ibm.box.com/s/y4wh104vdos1vw5kdjwwuhebf8jgq580)
     * [Exercise 4: Use Tekton and Kabanero Pipelines to continuously deploy](exercise-4/README.md)
 
-### Day 2 (In Progress)
+### Day 2
 
 * [About Day 2](about-day-2/README.md)
     * [Lecture 4: Customizing Appsody and Kabanero](https://ibm.box.com/s/kbuympaqftxswyi1aoswdlqussmqf1ba)
     * [Exercise 5: Customizing an existing Appsody Stack](exercise-5/README.md)
-    * [Exercise 6: Building a custom Kabanero Collection repository](exercise-6/README.md)
-    * [Exercise 7: Configuring Kabanero to use an Alternate Collection Repository](exercise-7/README.md)
+    * [Exercise 6: Building a custom Collection repository](exercise-6/README.md)
+    * [Exercise 7: Using a custom Collection with Appsody](exercise-7/README.md)
     * [Lecture 5: Tekton Overview](https://ibm.box.com/s/tg0f6nhs91trlzkb5pfnh5e1rdzg4wm6)
     * [Exercise 8: Create a custom Tekton Task and Pipleline](exercise-8/README.md)
-    * [Exercise 9: Deploy an application with a custom Stack, custom Collection, and custom Tekton Pipeline](exercise-9/README.md)
+    * [Exercise 9: Deploy an application with a custom Stack, custom Collection, and custom Pipeline](exercise-9/README.md)
 
 ### Workshop Resources
 

--- a/workshop/about-day-2/README.md
+++ b/workshop/about-day-2/README.md
@@ -1,17 +1,15 @@
 # Workshop Day 2
 
-## Day 2: Customizing Stacks, Pipelines in Kabanero Collections
+## Day 2: Customizing Stacks, Pipelines in Collections
 
-> ***WORK IN PROGRESS***
-
-In the second day we'll learn about Kabanero Enterprise and how to productionize our applications with custom Appsody Stacks, custom Kabanero collections, and custom Tekton pipelines.
+In the second day we'll learn about the Kabanero open source project and how to productionize our applications with custom Appsody Stacks, custom Collections, and custom Tekton pipelines.
 
 | Section | Description |
 | - | - |
 | **[Lecture 4: Customizing Appsody and Kabanero](https://ibm.box.com/s/kbuympaqftxswyi1aoswdlqussmqf1ba)** | Learn all about the stacks and repos |
-| **[Exercise 6: Building a custom Kabanero Collection](../exercise-6/README.md)** | Create a collection that will contain custom appsody stacks and pipelines |
+| **[Exercise 6: Building a custom Collection](../exercise-6/README.md)** | Create a collection that will contain custom appsody stacks and pipelines |
 | **[Exercise 5: Customizing an existing Appsody Stack](../exercise-5/README.md)** | Create a custom stack, to be hosted in our custom repository |
-| **[Exercise 7: Configuring Kabanero to use an Alternate Collection Repository](../exercise-7/README.md)** | Learn how to manage these custom stacks and how to make them available to developers |
+| **[Exercise 7: Using a custom Collection with Appsody](../exercise-7/README.md)** | Learn how to manage these custom stacks and how to make them available to developers |
 | **[Lecture 5: Tekton Overview](https://ibm.box.com/s/tg0f6nhs91trlzkb5pfnh5e1rdzg4wm6)** | Learn all Tekton CI/CD and how Kabanero uses it |
-| **[Exercise 8: Create a custom Tekton Task and Pipleline](../exercise-8/README.md)** | Build a pipeline that will fit into a custom Kabanero collection |
-| **[Exercise 9: Deploy an application with a custom Stack, custom Collection, and custom Tekton Pipeline](../exercise-9/README.md)** | Build and deploy an application using the custom stack, collection and pipelines built by the Architects' and Operators' tracks |
+| **[Exercise 8: Create a custom Tekton Task and Pipleline](../exercise-8/README.md)** | Build a pipeline that will fit into a custom Collection |
+| **[Exercise 9: Deploy an application with a custom Stack, custom Collection, and custom Pipeline](../exercise-9/README.md)** | Build and deploy an application using the custom stack, collection and pipelines built by the Architects' and Operators' tracks |

--- a/workshop/exercise-1/README.md
+++ b/workshop/exercise-1/README.md
@@ -34,7 +34,7 @@ appsody 0.5.3
 
 ### 1. Configure Appsody CLI
 
-In this section we'll configure our Appsody CLI to pull in Kabanero collections.
+In this section we'll configure our Appsody CLI to pull in Collections.
 
 #### List existing Appsody stacks
 
@@ -52,9 +52,9 @@ NAME            URL
 *incubator      https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
 ```
 
-The exact repo list may be different to the above. `incubator` is one of the repos in the appsody project public hub (`appsodyhub`). For this workshop we are going to use the private enterprise-grade collection of stacks that come with Kabanero Enterprise (which is part of Cloud Pak for Applications). So the first thing we need to do is to tell the CLI about this.
+The exact repo list may be different to the above. `incubator` is one of the repos in the appsody project public hub (`appsodyhub`). For this workshop we are going to use the private enterprise-grade collection of stacks that come with the Kabanero open source project (which is part of Cloud Pak for Applications). So the first thing we need to do is to tell the CLI about this.
 
-#### Add Kabanero Collection to Appsody
+#### Add Collection to Appsody
 
 From the Cloud Pak for Applications landing page get the `CollectionHub` URL, for example:
 
@@ -81,7 +81,7 @@ NAME            URL
 kabanero        https://github.com/kabanero-io/collections/releases/download/v0.1.2/kabanero-index.yaml
 ```
 
-We can now list the appsody stacks available in the Kabanero collection:
+We can now list the appsody stacks available in the Collection:
 
 ```bash
 appsody list kabanero

--- a/workshop/exercise-4/README.md
+++ b/workshop/exercise-4/README.md
@@ -9,7 +9,7 @@ Recall that the application from exercise 3 consists of:
 
 When you have completed this exercise, you will understand how to:
 
-* leverage Tekton pipelines with Kabanero collections to deploy applications to OpenShift
+* leverage Tekton pipelines with Collections to deploy applications to OpenShift
 
 ![Tools used during Exercise 4](images/ex4.png)
 

--- a/workshop/exercise-5/README.md
+++ b/workshop/exercise-5/README.md
@@ -3,12 +3,12 @@
 The goals for this day are to customize each of the pre-configured asset from Day 1, meaning we will:
 
 * extend an Appsody Stack
-* publish a new Kabanero collections
+* publish a new Collections
 * add a new Tekton task to our Tekton pipeline
 
 Specifically, when you have completed this exercise, you will understand how to:
 
-* extend an Appsody stack to create a new asset to be used in our Kabanero collection
+* extend an Appsody stack to create a new asset to be used in our Collection
 
 ![Tools used during Exercise 5](images/ex5.png)
 
@@ -58,7 +58,7 @@ A pictorial view of how an application developer uses a stack, looks like this:
 
 ![Appsody Flow](images/appsody.png)
 
-The above development flow shows the manual deployment to a Kubernetes cluster. In more production-orientated environments, GitOps might trigger the build and deploy steps and Tekton Pipelines would drive the deployment. [Kabanero Collections](https://github.com/kabanero-io/collections/), which is part of [Cloud Pak for Applications](https://www.ibm.com/cloud/cloud-pak-for-applications), brings together Appsody stacks, GitOps, and Tekton Pipelines to provide an enterprise-ready solution for cloud-native application development and deployment. We'll look at this in later exercises.
+The above development flow shows the manual deployment to a Kubernetes cluster. In more production-orientated environments, GitOps might trigger the build and deploy steps and Tekton Pipelines would drive the deployment. [Collections](https://github.com/kabanero-io/collections/), which are a part of [Cloud Pak for Applications](https://www.ibm.com/cloud/cloud-pak-for-applications), bring together Appsody stacks, GitOps, and Tekton Pipelines to provide an enterprise-ready solution for cloud-native application development and deployment. We'll look at this in later exercises.
 
 ### 2. Stack structure
 

--- a/workshop/exercise-6/README.md
+++ b/workshop/exercise-6/README.md
@@ -1,10 +1,10 @@
 # Exercise 6: Building a custom Appsody Stack Collection in Kabanero
 
-In this exercise, we will show how to create a custom Kabanero collection, that includes the custom Appsody Stack from the previous exercise.
+In this exercise, we will show how to create a custom Collection, that includes the custom Appsody Stack from the previous exercise.
 
 When you have completed this exercise, you will understand how to
 
-* clone and host your own Kabanero Collection
+* clone and host your own Collection
 * modify the Collection to include a custom Appsody Stack
 
 ![Tools used during Exercise 6](images/ex6.png)
@@ -29,7 +29,7 @@ pip install pyYAML
 
 ## About custom Kabanero Repositories
 
-By default Kabanero Enterprise is configured to automatically use the latest release at [https://github.com/kabanero-io/collections](https://github.com/kabanero-io/collections).
+By default the Kabanero open source project is configured to automatically use the latest release at [https://github.com/kabanero-io/collections](https://github.com/kabanero-io/collections).
 
 The default collections can be modified to meet an organization's unique needs.
 
@@ -39,7 +39,7 @@ The default collections can be modified to meet an organization's unique needs.
   * `incubator`: collections that are actively being worked on to satisfy the stable criteria.
   * `experimental`: collections that are used for trying out specific capabilities or proof of concept work.
 
-* Kabanero Collections include an Appsody stack, and a Tekton pipeline.
+* Collections include an Appsody stack, and a Tekton pipeline.
 
 ## Steps
 
@@ -72,7 +72,7 @@ git push -u my-org
 
 ```ini
 ci
-├── [ files used for CI/CD of the Kabanero collections ]
+├── [ files used for CI/CD of the Collections ]
 experimental (or incubator, or stable)
 ├── common/
 |   ├── pipelines/

--- a/workshop/exercise-9/README.md
+++ b/workshop/exercise-9/README.md
@@ -343,4 +343,4 @@ ain.cloud/
 Hello from a Custom Appsody Stack!* Connection #0 to host test-custom-stack-kabanero.timro-roks1-5290c8c8e5797924dc1ad5d1b85b37c0-0001.us-east.containers.appdomain.cloud left intact
 ```
 
-**Congratulations!!** You have completed Day 2 of the workshop! You have successfully created a custom appsody stack, included it in a custom kabanero collection that also includes a custom pipeline - showing how you can adapt the standard kabanero infrastructure to suit the needs of your enterprise.
+**Congratulations!!** You have completed Day 2 of the workshop! You have successfully created a custom appsody stack, included it in a custom Collection that also includes a custom pipeline - showing how you can adapt the standard kabanero infrastructure to suit the needs of your enterprise.


### PR DESCRIPTION
From Barbara:

> We are not referring to `Kabanero Enterprise` any longer, Can you change it `the Kabanero open source project`? Also `Kabanero Collections` should be just `Collections`.

I also snuck in a few changes to remove the "Work in progress" tags we had lingering around...